### PR TITLE
Add paths-ignore to release_draft workflows

### DIFF
--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -3,6 +3,7 @@ name: Draft release
 on:
   push:
     branches: [main]
+    paths-ignore: ['package-lock.json', ".*"]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This will skip running release draft when changes are to dev-only files.