### PR TITLE
Add config option to source an env setup script before ament

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ You can also save the configuration within your workspace like so:
       "task": "cppcheck", // The name of the problem matcher
       "path": "src/", // The path to your source files
       "commandOptions": "", // Optional additional command line options
+      "envSetup": "" // Optional setup to run before liner (ex: source /opt/ros/humble/setup.bash )
       "problemMatcher": [
         "$ament_cppcheck" // the corresponding problem matcher - can be used independently
       ],
@@ -55,6 +56,12 @@ You can also save the configuration within your workspace like so:
   ]
 }
 ```
+
+### Settings
+
+There is one optional setting that will set the setup script to run before the all of the linters in the workspace. This can be overwritten in the tasks.json file.
+
+![ament-task-provider-settings](https://github.com/athackst/vscode-ament-task-provider/assets/6098197/6b795b22-dd16-4820-8e46-df317ed293fe)
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -35,10 +35,21 @@
     },
     "icon": "leaf.png",
     "activationEvents": [
-        "onCommand:workbench.action.tasks.runTask"
+        "onCommand:workbench.action.tasks.runTask",
+        "onCommand:ament-task-provider.changeSetting"
     ],
     "main": "./out/src/extension",
     "contributes": {
+        "configuration": {
+            "title": "Ament Task Provider",
+            "properties": {
+                "ament-task-provider.envSetup": {
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "The command to setup the environment for ament tasks.\n\n*Example: source /opt/ros/humble/setup.bash*"
+                }
+            }
+        },
         "taskDefinitions": [
             {
                 "type": "ament",
@@ -66,6 +77,10 @@
                     "commandOptions": {
                         "type": "string",
                         "description": "(Optional) command line arguments for the linter."
+                    },
+                    "envSetup": {
+                        "type": "string",
+                        "description": "(Optional) The env setup script to use for ament tasks"
                     }
                 }
             }


### PR DESCRIPTION
Adds a task property and a workspace configuration option for a command to run before running the ament linters.  This allows users to source the ros setup script before running a linter.

This can be set as a workspace setting, which will apply to all ament tasks

![ament-task-provider-settings](https://github.com/athackst/vscode-ament-task-provider/assets/6098197/6b795b22-dd16-4820-8e46-df317ed293fe)

Or per task so that tasks can be configured with different sources.

```jsonc
        {
            "label": "flake8",
            "detail": "Run flake8 on python files.",
            "type": "ament",
            "task": "flake8",
            "path": "src/",
            "envSetup": "source /opt/ros/humble/setup.bash",
            "problemMatcher": "$ament_flake8",
            "presentation": {
                "panel": "dedicated",
                "reveal": "silent",
                "clear": true
            }
        },
```

By default, no setup script is specified.

Closes #309 